### PR TITLE
fix(cc-station-login): add-isagentloggedin-parameter

### DIFF
--- a/packages/contact-center/station-login/src/station-login/index.tsx
+++ b/packages/contact-center/station-login/src/station-login/index.tsx
@@ -8,13 +8,14 @@ import {useStationLogin} from '../helper';
 import { StationLoginProps } from './station-login.types';
 
 const StationLogin: React.FunctionComponent<StationLoginProps> = observer(({onLogin, onLogout}) => {
-  const {cc, teams, loginOptions} = store;
+  const {cc, teams, loginOptions, isAgentLoggedIn} = store;
   const result = useStationLogin({cc, onLogin, onLogout});
 
   const props = {
     ...result,
     teams,
-    loginOptions
+    loginOptions,
+    isAgentLoggedIn
   };
   return <StationLoginPresentational {...props} />;
 });

--- a/packages/contact-center/station-login/src/station-login/station-login.presentational.tsx
+++ b/packages/contact-center/station-login/src/station-login/station-login.presentational.tsx
@@ -2,7 +2,7 @@ import React, {useEffect} from 'react';
 import {StationLoginPresentationalProps} from './station-login.types';
 
 const StationLoginPresentational: React.FunctionComponent<StationLoginPresentationalProps> = (props) => {
-  const {name, teams, loginOptions, login, logout, setDeviceType, setDialNumber, setTeam} = props; // TODO: Use the  loginSuccess, loginFailure, logoutSuccess props returned fromthe API response via helper file to reflect UI changes
+  const {name, teams, loginOptions, isAgentLoggedIn, login, logout, setDeviceType, setDialNumber, setTeam} = props; // TODO: Use the  loginSuccess, loginFailure, logoutSuccess props returned fromthe API response via helper file to reflect UI changes
 
   useEffect(() => {
     const teamsDropdown = document.getElementById('teamsDropdown') as HTMLSelectElement;
@@ -124,7 +124,7 @@ const StationLoginPresentational: React.FunctionComponent<StationLoginPresentati
                   <option value="" selected hidden>Choose Agent Login Option...</option>
                 </select>
                 <input style={styles.input} id="dialNumber" name="dialNumber" placeholder="Extension/Dial Number" type="text" onInput={updateDN} />
-                <button id="AgentLogin" style={styles.btn} onClick={login}>Login</button>
+                <button id="AgentLogin" style={styles.btn} onClick={login} disabled={isAgentLoggedIn}>Login</button>
                 <button id="logoutAgent" style={styles.btn} onClick={logout}>Logout</button>
               </fieldset>
             </div>

--- a/packages/contact-center/station-login/src/station-login/station-login.types.ts
+++ b/packages/contact-center/station-login/src/station-login/station-login.types.ts
@@ -72,9 +72,14 @@ export interface IStationLoginProps {
    * Handler to set the selected agent team
    */
   setTeam: (team: string) => void;
+
+  /**
+   * Indicates whether the agent is currently logged in.
+   */
+  isAgentLoggedIn:boolean
 }
 
-export type StationLoginPresentationalProps = Pick<IStationLoginProps, 'name' | 'teams' | 'loginOptions' | 'login' | 'logout' | 'loginSuccess' | 'loginFailure' | 'logoutSuccess' | 'setDeviceType' | 'setDialNumber' | 'setTeam'>;
+export type StationLoginPresentationalProps = Pick<IStationLoginProps, 'name' | 'teams' | 'loginOptions' | 'login' | 'logout' | 'loginSuccess' | 'loginFailure' | 'logoutSuccess' | 'setDeviceType' | 'setDialNumber' | 'setTeam' | 'isAgentLoggedIn'>;
 
 export type UseStationLoginProps = Pick<IStationLoginProps, 'cc' | 'onLogin' | 'onLogout'>;
 

--- a/packages/contact-center/store/src/store.ts
+++ b/packages/contact-center/store/src/store.ts
@@ -1,7 +1,6 @@
 import {makeAutoObservable, observable} from 'mobx';
 import Webex from 'webex';
 import {
-  AgentLogin,
   IContactCenter,
   Profile,
   Team,
@@ -14,6 +13,7 @@ class Store implements IStore {
   teams: Team[] = [];
   loginOptions: string[] = [];
   cc: IContactCenter;
+  isAgentLoggedIn: boolean = false;
 
   constructor() {
     makeAutoObservable(this, {cc: observable.ref});
@@ -24,6 +24,7 @@ class Store implements IStore {
     return this.cc.register().then((response: Profile) => {
       this.teams = response.teams;
       this.loginOptions = response.loginVoiceOptions;
+      this.isAgentLoggedIn = response.isAgentLoggedIn;
     }).catch((error) => {
       console.error('Error registering contact center', error);
       return Promise.reject(error);

--- a/packages/contact-center/store/src/store.types.ts
+++ b/packages/contact-center/store/src/store.types.ts
@@ -15,6 +15,7 @@ interface IStore {
     teams: Team[];
     loginOptions: string[];
     cc: IContactCenter;
+    isAgentLoggedIn: boolean;
   
     registerCC(webex: WithWebex['webex']): Promise<Profile>;
     init(params: InitParams): Promise<void>;


### PR DESCRIPTION
# Do not merge
## This PR PARTIALLY completes [Add the JIRA]

We read the isAentLoggedIn parameter from the response  we get from cc.register(). If the paramter is true we disable the login button.

## Some open item
- We don't get any data about what type of login it was. Desktop, Browser
- How should we handle Mobius registration?
- We would need the information about the last login. What type of login was done before? If it was DN what was the direct number? If it was ext what was the ext number

## Testing done
- No testing is done as of now

## What does this PR handle?
- This PR was quickly created to handle the relogin part. If the agent is logged in somewhere else, or we do a refresh. The widgets wont throw any error. 